### PR TITLE
update `basic_eww`

### DIFF
--- a/examples/basic_eww/eww-bar/eww.scss
+++ b/examples/basic_eww/eww-bar/eww.scss
@@ -49,6 +49,10 @@
 .label-ram {
   font-size: large;
 }
+.workspaces button {
+  font-size: 24px;
+  padding: 6px;
+}
 .workspaces button:hover {
   color: #D35D6E;
 }
@@ -59,6 +63,10 @@
 .ws-button-visible {
   color: #D35D6E;
   background-color: #4e4e4e;
+}
+.ws-button-urgent {
+  color: #ffd5ca;
+  background-color: #D35D6E;
 }
 .ws-button-busy {
   color: #D35D6E;

--- a/examples/basic_eww/eww-bar/eww.yuck
+++ b/examples/basic_eww/eww-bar/eww.yuck
@@ -17,30 +17,23 @@
             :onchange "")
     time))
 
-; Preview on how the workspaces widget will render:
-; (defwidget workspaces []
-    ; (box :class "workspaces"
-         ; :orientation "h"
-         ; :space-evenly true
-         ; :halign "start"
-         ; :spacing 10
-            ; (button :class "ws-button-mine" :onclick "leftwm-command \"SendWorkspaceToTag 0 0\"" `1`)
-            ; (button :class "ws-button-busy" :onclick "leftwm-command \"SendWorkspaceToTag 0 1\"" `2`)
-            ; (button :class "ws-button-busy" :onclick "leftwm-command \"SendWorkspaceToTag 0 2\"" `3`)
-            ; (button :class "ws-button" :onclick "leftwm-command \"SendWorkspaceToTag 0 3\"" `·`)
-            ; (button :class "ws-button" :onclick "leftwm-command \"SendWorkspaceToTag 0 4\"" `·`)
-            ; (button :class "ws-button" :onclick "leftwm-command \"SendWorkspaceToTag 0 5\"" `·`)
-            ; (button :class "ws-button" :onclick "leftwm-command \"SendWorkspaceToTag 0 6\"" `·`)
-            ; (button :class "ws-button" :onclick "leftwm-command \"SendWorkspaceToTag 0 7\"" `·`)
-            ; (button :class "ws-button" :onclick "leftwm-command \"SendWorkspaceToTag 0 8\"" `·`)))
-
+; eww is natively able to parse the JSON output of `leftwm-state`
+; since eww also has the ability of `for` loops there is no need for a `liquid` template anymore
 (defwidget workspaces []
-  (box :class "workspaces"
-       :orientation "h"
-       :space-evenly true
-       :halign "start"
-       :spacing 10
-    (literal :content {wm-tags})))
+    (box :class "workspaces"
+         :orientation "h"
+         :space-evenly true
+         :halign "start"
+         :spacing 10
+      (box
+        (for tag in '${wmstate.workspaces[0].tags}'
+          (button
+            :class {tag.mine ? "ws-button-mine" :
+                    tag.visible ? "ws-button-visible" :
+                    tag.urgent ? "ws-button-urgent" :
+                    tag.busy ? "ws-button-busy" : "ws-button"}
+            :onclick "leftwm-command \"SendWorkspaceToTag 0 ${tag.index}\""
+            {!tag.mine && !tag.busy && !tag.visible && !tag.urgent ?  "·" : "${tag.name}"})))))
 
 (defwidget music []
   (box :class "music"
@@ -72,8 +65,9 @@
 (defpoll time :interval "10s"
   "date '+%H:%M %b %d, %Y'")
 
-(deflisten wm-tags
-  "leftwm-state -w 0 -t ~/.config/leftwm/themes/current/template.liquid")
+(deflisten wmstate 
+           :initial '{"workspaces":[{"layout":"","tags":[{"name":"","index":0,"mine":false,"busy":false,"visible":false,"urgent":false}]}]}'
+           "leftwm state")
 
 (defwindow bar0
   :monitor 0


### PR DESCRIPTION
This updetes the `basic_eww` theme example to reflect the ability of eww to process the JSON output of `leftwm-state` itself and also to process tags in a for-loop.

Also adds the `urgent` flag for tags, added with leftwm/leftwm#805.